### PR TITLE
Fix typos for Schotten Totten

### DIFF
--- a/src/content/games-md/schotten-totten.mdoc
+++ b/src/content/games-md/schotten-totten.mdoc
@@ -30,9 +30,9 @@ mapping:
   compatibility: 4
 ---
 
-## Cards selection and drawing
+## Card selection and drawing
 
-To play Schotten Totten you need 64 cards plus 9 optional ones and a minimum of 10 drawings, up to 20 for better playability.
+To play Schotten Totten, you need 64 cards plus 9 optional ones and a minimum of 10 drawings, up to 20 for better playability.
 
 ### Instructions
 
@@ -56,13 +56,13 @@ To play Schotten Totten you need 64 cards plus 9 optional ones and a minimum of 
 1. Pick the ranks 1 to 9 from every chosen suit.
 1. Select 10 cards from any other suit.
    {% callout type="idea" %}
-   Chose a black suit, so it's easy to tell appart the two kind of cards. Alternatively, chose 0s of any suit.
+   Chose a black suit, so it's easy to tell the two kind of cards apart. Alternatively, chose 0s of any suit.
    {% /callout %}
 1. Draw the Tactic cards icons in the drawing area B of those 10 cards. Remember that there are 2 jokers.
    {% callout type="idea" %}
-   You can draw in only one corner to save up space, but it will be inconvinient while playing.
+   You can draw in only one corner to save up space, but it will be inconvenient while playing.
    {% /callout %}
-1. Use any 9 unused card backs as Stones tiles.
+1. Use any 9 unused card backs as Stone tiles.
    {% callout type="idea" %}
    You can use tokens as Stone tiles instead.
    {% /callout %}


### PR DESCRIPTION
I noticed a few typos when reading through the rules. I'll note that the image also has a minor typo with a missing f on "Bluf."